### PR TITLE
Pivot icons for Mobile screen size

### DIFF
--- a/src/Kliva/Controls/ActivityDetailControl.xaml
+++ b/src/Kliva/Controls/ActivityDetailControl.xaml
@@ -82,7 +82,11 @@
             <Pivot x:Name="ActivityPivot"
                    RelativePanel.Below="ActivityDetailCommandBar"
                    RelativePanel.AlignLeftWithPanel="True" RelativePanel.AlignRightWithPanel="True" RelativePanel.AlignBottomWithPanel="True">
-                <PivotItem x:Name="StatisticsPivot" Header="statistics" Tag="Statistics">
+                <PivotItem x:Name="StatisticsPivot" Tag="Statistics">
+                    <PivotItem.Header>
+                        <local:IconPivotHeader Label="statistics"
+                                               Glyph="&#xE1E9;" />
+                    </PivotItem.Header>
                     <ScrollViewer VerticalScrollBarVisibility="Auto" HorizontalScrollMode="Disabled">
                         <RelativePanel Margin="10,0,0,0">
                             <!-- DISTANCE BLOCK -->
@@ -209,15 +213,21 @@
                     </ScrollViewer>
                 </PivotItem>
                 <PivotItem x:Name="SegmentsPivot" Tag="Segments"
-                           Header="{x:Bind ViewModel.SelectedActivity.SegmentEffortsCount, Converter={StaticResource AddAmountToStringConverter}, ConverterParameter=segments, Mode=OneWay}"
-                    x:DeferLoadStrategy="Lazy"
+                           x:DeferLoadStrategy="Lazy"
                            Visibility="{x:Bind ViewModel.HasSegments, Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}">
+                    <PivotItem.Header>
+                        <local:IconPivotHeader Label="{x:Bind ViewModel.SelectedActivity.SegmentEffortsCount, Converter={StaticResource AddAmountToStringConverter}, ConverterParameter=segments, Mode=OneWay}"
+                                               Glyph="&#xEC1B;" />
+                    </PivotItem.Header>
                     <ListView x:Name="AcitivtySegmentsList"
                               ItemsSource="{x:Bind ViewModel.SelectedActivity.SegmentEfforts, Mode=OneWay}"
                               ItemTemplate="{StaticResource SegmentEffortListItemTemplate}"/>
                 </PivotItem>
-                <PivotItem x:Name="KudosPivot" Tag="Kudos"
-                           Header="{x:Bind ViewModel.KudosCount, Converter={StaticResource AddAmountToStringConverter}, ConverterParameter=kudos, Mode=OneWay}">
+                <PivotItem x:Name="KudosPivot" Tag="Kudos">
+                    <PivotItem.Header>
+                        <local:IconPivotHeader Label="{x:Bind ViewModel.KudosCount, Converter={StaticResource AddAmountToStringConverter}, ConverterParameter=kudos, Mode=OneWay}"
+                                               Glyph="&#xE8E1;" />
+                    </PivotItem.Header>
                     <ListView x:Name="ActivityKudosList"
                               ItemsSource="{x:Bind ViewModel.Kudos, Mode=OneWay}"
                               ItemTemplate="{StaticResource KudosListItemTemplate}"
@@ -229,16 +239,22 @@
                         </interactivity:Interaction.Behaviors>
                     </ListView>
                 </PivotItem>
-                <PivotItem x:Name="CommentsPivot" Tag="Comments"
-                           Header="{x:Bind ViewModel.CommentCount, Converter={StaticResource AddAmountToStringConverter}, ConverterParameter=comments, Mode=OneWay}">
+                <PivotItem x:Name="CommentsPivot" Tag="Comments">
+                    <PivotItem.Header>
+                        <local:IconPivotHeader Label="{x:Bind ViewModel.CommentCount, Converter={StaticResource AddAmountToStringConverter}, ConverterParameter=comments, Mode=OneWay}"
+                                               Glyph="&#xE8BD;" />
+                    </PivotItem.Header>
                     <ListView x:Name="ActivityCommentsList"
                               ItemsSource="{x:Bind ViewModel.Comments, Mode=OneWay}"
                               ItemTemplate="{StaticResource CommentsListItemTemplate}"/>
                 </PivotItem>
                 <PivotItem x:Name="PhotosPivot" Tag="Photos"
-                           x:DeferLoadStrategy="Lazy"
-                           Header="{x:Bind ViewModel.PhotoCount, Converter={StaticResource AddAmountToStringConverter}, ConverterParameter=photos, Mode=OneWay}"
+                           x:DeferLoadStrategy="Lazy"                           
                            Visibility="{x:Bind ViewModel.HasPhotos, Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}">
+                    <PivotItem.Header>
+                        <local:IconPivotHeader Label="{x:Bind ViewModel.PhotoCount, Converter={StaticResource AddAmountToStringConverter}, ConverterParameter=photos, Mode=OneWay}"
+                                               Glyph="&#xEB9F;" />
+                    </PivotItem.Header>
                     <GridView x:Name="ActivityPhotosGrid"
                               Margin="10,0,0,0"
                               ItemsSource="{x:Bind ViewModel.SelectedActivity.AllPhotos, Mode=OneWay}"

--- a/src/Kliva/Controls/IconPivotHeader.xaml
+++ b/src/Kliva/Controls/IconPivotHeader.xaml
@@ -1,0 +1,48 @@
+﻿<UserControl
+    x:Class="Kliva.Controls.IconPivotHeader"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:Kliva.Controls"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    d:DesignHeight="300"
+    d:DesignWidth="400">
+
+    <Grid>
+        <VisualStateManager.VisualStateGroups>
+            <VisualStateGroup x:Name="VisualStateGroup">
+                <VisualState x:Name="Mobile">
+                    <VisualState.StateTriggers>
+                        <AdaptiveTrigger MinWindowWidth="320" />
+                    </VisualState.StateTriggers>
+                    <VisualState.Setters>
+                        <Setter Target="Icon.(RelativePanel.AlignHorizontalCenterWithPanel)" Value="True" />
+                        <Setter Target="LabelText.(RelativePanel.Below)" Value="Icon" />
+                        <Setter Target="LabelText.(RelativePanel.AlignHorizontalCenterWith)" Value="Icon" />
+                        <Setter Target="LabelText.Margin" Value="2,4,2,4" />
+                        <Setter Target="LabelText.Style" Value="{StaticResource CaptionTextBlockStyle}" />
+                    </VisualState.Setters>
+                </VisualState>
+                <VisualState x:Name="Desktop">
+                    <VisualState.StateTriggers>
+                        <AdaptiveTrigger MinWindowWidth="720" />
+                    </VisualState.StateTriggers>
+                    <VisualState.Setters>
+                        <Setter Target="Icon.Visibility" Value="Collapsed" />
+                        <Setter Target="LabelText.(RelativePanel.AlignLeftWithPanel)" Value="True" />
+                    </VisualState.Setters>
+                </VisualState>
+            </VisualStateGroup>
+        </VisualStateManager.VisualStateGroups>
+        <RelativePanel x:Name="RelativePanel">
+            <FontIcon x:Name="Icon"
+                      HorizontalAlignment="Center"
+                      Margin="0,10,0,0"
+                      Glyph="{Binding Glyph}"
+                      FontSize="16" />
+            <TextBlock x:Name="LabelText"
+                       Text="{Binding Label}" />
+        </RelativePanel>
+    </Grid>
+</UserControl>

--- a/src/Kliva/Controls/IconPivotHeader.xaml.cs
+++ b/src/Kliva/Controls/IconPivotHeader.xaml.cs
@@ -1,0 +1,30 @@
+﻿using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+
+namespace Kliva.Controls
+{
+    public sealed partial class IconPivotHeader : UserControl
+    {
+        public static readonly DependencyProperty GlyphProperty = DependencyProperty.Register("Glyph", typeof(string), typeof(IconPivotHeader), null);
+
+        public string Glyph
+        {
+            get { return GetValue(GlyphProperty) as string; }
+            set { SetValue(GlyphProperty, value); }
+        }
+
+        public static readonly DependencyProperty LabelProperty = DependencyProperty.Register("Label", typeof(string), typeof(IconPivotHeader), null);
+
+        public string Label
+        {
+            get { return GetValue(LabelProperty) as string; }
+            set { SetValue(LabelProperty, value); }
+        }
+
+        public IconPivotHeader()
+        {
+            this.InitializeComponent();
+            this.DataContext = this;
+        }
+    }
+}

--- a/src/Kliva/Kliva.csproj
+++ b/src/Kliva/Kliva.csproj
@@ -115,6 +115,9 @@
       <DependentUpon>ClubFeedControl.xaml</DependentUpon>
     </Compile>
     <Compile Include="Controls\GoogleImageDependencyObject.cs" />
+    <Compile Include="Controls\IconPivotHeader.xaml.cs">
+      <DependentUpon>IconPivotHeader.xaml</DependentUpon>
+    </Compile>
     <Compile Include="Controls\KlivaApplicationFrame.cs" />
     <Compile Include="Controls\MenuItemTemplateSelector.cs" />
     <Compile Include="Controls\SidePaneControl.xaml.cs">
@@ -278,6 +281,10 @@
       <Generator>MSBuild:Compile</Generator>
     </Page>
     <Page Include="Controls\ClubFeedControl.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="Controls\IconPivotHeader.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>

--- a/src/Kliva/Kliva.csproj.user
+++ b/src/Kliva/Kliva.csproj.user
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
-    <DeviceId>9E663E22-CF9E-4F8A-AAC9-DC758E55304E</DeviceId>
-    <UseEmulator>false</UseEmulator>
+    <DeviceId>90F4E8F4-EC5F-4B64-B2E8-6EDE6F813BD3</DeviceId>
+    <UseEmulator>true</UseEmulator>
     <RemoteDebugMachine>DepSurface</RemoteDebugMachine>
     <AuthenticationMode>Windows</AuthenticationMode>
     <RemoteDebugEnabled>false</RemoteDebugEnabled>

--- a/src/Kliva/XAMLResources/Styles.xaml
+++ b/src/Kliva/XAMLResources/Styles.xaml
@@ -986,7 +986,7 @@
         <Setter Property="Foreground" Value="{StaticResource KlivaMainColor}" />
         <!-- original value {ThemeResource SystemControlForegroundBaseMediumBrush} -->
         <Setter Property="Padding" Value="{ThemeResource PivotHeaderItemMargin}" />
-        <Setter Property="Height" Value="48" />
+        <Setter Property="Height" Value="Auto" />
         <Setter Property="VerticalContentAlignment" Value="Center" />
         <Setter Property="IsTabStop" Value="False" />
         <Setter Property="Template">


### PR DESCRIPTION
Enable pivot icons with sub labels on Mobile screen size for the Activity Detail pivot items
