### PR TITLE
ListView of activities - slidable actions

### DIFF
--- a/src/Kliva/Controls/ActivityFeedControl.xaml.cs
+++ b/src/Kliva/Controls/ActivityFeedControl.xaml.cs
@@ -317,7 +317,7 @@ namespace Kliva.Controls
             var itemContainer = (ListViewItem)sender;
             var itemIndex = ActivityList.IndexFromContainer(itemContainer);
 
-            var uc = itemContainer.ContentTemplateRoot as UserControl;
+            var uc = itemContainer.ContentTemplateRoot as FrameworkElement;
             var childPanel = uc.FindName("ActivityListItemPanel") as RelativePanel;
 
             // Don't animate if we're not in the visible viewport

--- a/src/Kliva/Messages/ActivitySummaryMessage.cs
+++ b/src/Kliva/Messages/ActivitySummaryMessage.cs
@@ -12,4 +12,18 @@ namespace Kliva.Messages
             ActivitySummary = activitySummary;
         }
     }
+
+    public class ActivitySummaryKudosMessage : ActivitySummaryMessage
+    {
+        public ActivitySummaryKudosMessage(ActivitySummary activitySummary) : base(activitySummary)
+        {
+        }
+    }
+
+    public class ActivitySummaryCommentMessage : ActivitySummaryMessage
+    {
+        public ActivitySummaryCommentMessage(ActivitySummary activitySummary) : base(activitySummary)
+        {
+        }
+    }
 }

--- a/src/Kliva/ViewModels/ActivityDetailViewModel.cs
+++ b/src/Kliva/ViewModels/ActivityDetailViewModel.cs
@@ -92,10 +92,10 @@ namespace Kliva.ViewModels
         public int PhotoCount => SelectedActivity?.TotalPhotoCount ?? 0;
 
         private RelayCommand _kudosCommand;
-        public RelayCommand KudosCommand => _kudosCommand ?? (_kudosCommand = new RelayCommand(async () => await OnKudosAsync(SelectedActivity.Id), () => SelectedActivity != null));
+        public RelayCommand KudosCommand => _kudosCommand ?? (_kudosCommand = new RelayCommand(async () => await OnKudosAsync(SelectedActivity.Id)));
 
         private RelayCommand _commentCommand;
-        public RelayCommand CommentCommand => _commentCommand ?? (_commentCommand = new RelayCommand(async () => await OnCommentAsync(SelectedActivity.Id), () => SelectedActivity != null));
+        public RelayCommand CommentCommand => _commentCommand ?? (_commentCommand = new RelayCommand(async () => await OnCommentAsync(SelectedActivity.Id)));
 
         private RelayCommand _mapCommand;
         public RelayCommand MapCommand => _mapCommand ?? (_mapCommand = new RelayCommand(() => NavigationService.Navigate<MapPage>(SelectedActivity?.Map)));

--- a/src/Kliva/ViewModels/ActivityDetailViewModel.cs
+++ b/src/Kliva/ViewModels/ActivityDetailViewModel.cs
@@ -92,10 +92,10 @@ namespace Kliva.ViewModels
         public int PhotoCount => SelectedActivity?.TotalPhotoCount ?? 0;
 
         private RelayCommand _kudosCommand;
-        public RelayCommand KudosCommand => _kudosCommand ?? (_kudosCommand = new RelayCommand(async () => await OnKudosAsync(this.SelectedActivity.Id)));
+        public RelayCommand KudosCommand => _kudosCommand ?? (_kudosCommand = new RelayCommand(async () => await OnKudosAsync(SelectedActivity.Id), () => SelectedActivity != null));
 
         private RelayCommand _commentCommand;
-        public RelayCommand CommentCommand => _commentCommand ?? (_commentCommand = new RelayCommand(async () => await OnCommentAsync(this.SelectedActivity.Id)));
+        public RelayCommand CommentCommand => _commentCommand ?? (_commentCommand = new RelayCommand(async () => await OnCommentAsync(SelectedActivity.Id), () => SelectedActivity != null));
 
         private RelayCommand _mapCommand;
         public RelayCommand MapCommand => _mapCommand ?? (_mapCommand = new RelayCommand(() => NavigationService.Navigate<MapPage>(SelectedActivity?.Map)));

--- a/src/Kliva/ViewModels/ActivityDetailViewModel.cs
+++ b/src/Kliva/ViewModels/ActivityDetailViewModel.cs
@@ -199,8 +199,8 @@ namespace Kliva.ViewModels
             {
                 await _stravaService.PostComment(activityId.ToString(), dialog.Description);
                 await LoadActivityDetails(activityId.ToString());
+                ServiceLocator.Current.GetInstance<IMessenger>().Send<PivotMessage<ActivityPivots>>(new PivotMessage<ActivityPivots>(ActivityPivots.Comments, true, true), Tokens.ActivityPivotMessage);
             }
-            ServiceLocator.Current.GetInstance<IMessenger>().Send<PivotMessage<ActivityPivots>>(new PivotMessage<ActivityPivots>(ActivityPivots.Comments, true, true), Tokens.ActivityPivotMessage);
         }
 
         private async Task OnEditAsync()

--- a/src/Kliva/ViewModels/ActivityDetailViewModel.cs
+++ b/src/Kliva/ViewModels/ActivityDetailViewModel.cs
@@ -137,7 +137,7 @@ namespace Kliva.ViewModels
 
             //TODO: Glenn - Why aren't we receiving private activities?
             var activity = await _stravaService.GetActivityAsync(activityId, true);
-            _athlete = await _stravaService.GetAthleteAsync();
+            _athlete = _athlete ?? await this._stravaService.GetAthleteAsync();
 
             if (activity != null)
             {
@@ -183,8 +183,13 @@ namespace Kliva.ViewModels
 
         private async Task OnKudosAsync(long activityId)
         {
-            await _stravaService.GiveKudosAsync(activityId.ToString());
-            await LoadActivityDetails(activityId.ToString());
+            _athlete = _athlete ?? await this._stravaService.GetAthleteAsync();
+            var canGiveKudos = _athlete.Id != SelectedActivity.Athlete.Id && !SelectedActivity.HasKudoed;
+            if (canGiveKudos)
+            {
+                await _stravaService.GiveKudosAsync(activityId.ToString());
+                await LoadActivityDetails(activityId.ToString());
+            }
             ServiceLocator.Current.GetInstance<IMessenger>().Send<PivotMessage<ActivityPivots>>(new PivotMessage<ActivityPivots>(ActivityPivots.Kudos, true, true), Tokens.ActivityPivotMessage);
         }
 

--- a/src/Kliva/ViewModels/MainViewModel.cs
+++ b/src/Kliva/ViewModels/MainViewModel.cs
@@ -96,10 +96,10 @@ namespace Kliva.ViewModels
         public RelayCommand SettingsCommand => _settingsCommand ?? (_settingsCommand = new RelayCommand(() => NavigationService.Navigate<SettingsPage>()));
 
         private RelayCommand<ActivitySummary> _kudosCommand;
-        public RelayCommand<ActivitySummary> KudosCommand => _kudosCommand ?? (_kudosCommand = new RelayCommand<ActivitySummary>(OnKudosAsync));
+        public RelayCommand<ActivitySummary> KudosCommand => _kudosCommand ?? (_kudosCommand = new RelayCommand<ActivitySummary>(OnKudos));
 
         private RelayCommand<ActivitySummary> _commentCommand;
-        public RelayCommand<ActivitySummary> CommentCommand => _commentCommand ?? (_commentCommand = new RelayCommand<ActivitySummary>(OnCommentAsync));
+        public RelayCommand<ActivitySummary> CommentCommand => _commentCommand ?? (_commentCommand = new RelayCommand<ActivitySummary>(OnComment));
 
         public MainViewModel(INavigationService navigationService, ISettingsService settingsService, IStravaService stravaService, IOService ioService) : base(navigationService)
         {
@@ -180,7 +180,7 @@ namespace Kliva.ViewModels
             }
         }
 
-        private void OnKudosAsync(ActivitySummary activitySummary)
+        private void OnKudos(ActivitySummary activitySummary)
         {
             // make sure we work with the swiped item
             // this could happen if we use the mouse to swipe and move the mouse outside the ListView and release it there
@@ -191,7 +191,7 @@ namespace Kliva.ViewModels
             MessengerInstance.Send<ActivitySummaryKudosMessage>(new ActivitySummaryKudosMessage(SelectedActivity));
         }
 
-        private void OnCommentAsync(ActivitySummary activitySummary)
+        private void OnComment(ActivitySummary activitySummary)
         {
             // make sure we work with the swiped item
             // this could happen if we use the mouse to swipe and move the mouse outside the ListView and release it there

--- a/src/Kliva/ViewModels/MainViewModel.cs
+++ b/src/Kliva/ViewModels/MainViewModel.cs
@@ -95,6 +95,34 @@ namespace Kliva.ViewModels
         private RelayCommand _settingsCommand;
         public RelayCommand SettingsCommand => _settingsCommand ?? (_settingsCommand = new RelayCommand(() => NavigationService.Navigate<SettingsPage>()));
 
+        private RelayCommand<ActivitySummary> _kudosCommand;
+        public RelayCommand<ActivitySummary> KudosCommand => _kudosCommand ?? (_kudosCommand = new RelayCommand<ActivitySummary>(async (x) => await OnKudosAsync(x)));
+
+        private RelayCommand<ActivitySummary> _commentCommand;
+        public RelayCommand<ActivitySummary> CommentCommand => _commentCommand ?? (_commentCommand = new RelayCommand<ActivitySummary>(async (x) => await OnCommentAsync(x)));
+
+        private async Task OnKudosAsync(ActivitySummary activitySummary)
+        {
+            // make sure we work with the swiped item
+            // this could happen if we use the mouse to swipe and move the mouse outside the ListView and release it there
+            if (activitySummary != this.SelectedActivity)
+            {
+                this.SelectedActivity = activitySummary;
+            }
+            MessengerInstance.Send<ActivitySummaryKudosMessage>(new ActivitySummaryKudosMessage(_selectedActivity));
+        }
+
+        private async Task OnCommentAsync(ActivitySummary activitySummary)
+        {
+            // make sure we work with the swiped item
+            // this could happen if we use the mouse to swipe and move the mouse outside the ListView and release it there
+            if (activitySummary != this.SelectedActivity)
+            {
+                this.SelectedActivity = activitySummary;
+            }
+            MessengerInstance.Send<ActivitySummaryCommentMessage>(new ActivitySummaryCommentMessage(_selectedActivity));
+        }
+
         public MainViewModel(INavigationService navigationService, ISettingsService settingsService, IStravaService stravaService, IOService ioService) : base(navigationService)
         {
             _settingsService = settingsService;

--- a/src/Kliva/ViewModels/MainViewModel.cs
+++ b/src/Kliva/ViewModels/MainViewModel.cs
@@ -96,32 +96,10 @@ namespace Kliva.ViewModels
         public RelayCommand SettingsCommand => _settingsCommand ?? (_settingsCommand = new RelayCommand(() => NavigationService.Navigate<SettingsPage>()));
 
         private RelayCommand<ActivitySummary> _kudosCommand;
-        public RelayCommand<ActivitySummary> KudosCommand => _kudosCommand ?? (_kudosCommand = new RelayCommand<ActivitySummary>(async (x) => await OnKudosAsync(x)));
+        public RelayCommand<ActivitySummary> KudosCommand => _kudosCommand ?? (_kudosCommand = new RelayCommand<ActivitySummary>(OnKudosAsync));
 
         private RelayCommand<ActivitySummary> _commentCommand;
-        public RelayCommand<ActivitySummary> CommentCommand => _commentCommand ?? (_commentCommand = new RelayCommand<ActivitySummary>(async (x) => await OnCommentAsync(x)));
-
-        private async Task OnKudosAsync(ActivitySummary activitySummary)
-        {
-            // make sure we work with the swiped item
-            // this could happen if we use the mouse to swipe and move the mouse outside the ListView and release it there
-            if (activitySummary != this.SelectedActivity)
-            {
-                this.SelectedActivity = activitySummary;
-            }
-            MessengerInstance.Send<ActivitySummaryKudosMessage>(new ActivitySummaryKudosMessage(_selectedActivity));
-        }
-
-        private async Task OnCommentAsync(ActivitySummary activitySummary)
-        {
-            // make sure we work with the swiped item
-            // this could happen if we use the mouse to swipe and move the mouse outside the ListView and release it there
-            if (activitySummary != this.SelectedActivity)
-            {
-                this.SelectedActivity = activitySummary;
-            }
-            MessengerInstance.Send<ActivitySummaryCommentMessage>(new ActivitySummaryCommentMessage(_selectedActivity));
-        }
+        public RelayCommand<ActivitySummary> CommentCommand => _commentCommand ?? (_commentCommand = new RelayCommand<ActivitySummary>(OnCommentAsync));
 
         public MainViewModel(INavigationService navigationService, ISettingsService settingsService, IStravaService stravaService, IOService ioService) : base(navigationService)
         {
@@ -200,6 +178,28 @@ namespace Kliva.ViewModels
                     ActivityIncrementalCollection = new MyActivityIncrementalCollection(_stravaService);
                     break;
             }
+        }
+
+        private void OnKudosAsync(ActivitySummary activitySummary)
+        {
+            // make sure we work with the swiped item
+            // this could happen if we use the mouse to swipe and move the mouse outside the ListView and release it there
+            if (activitySummary != SelectedActivity)
+            {
+                SelectedActivity = activitySummary;
+            }
+            MessengerInstance.Send<ActivitySummaryKudosMessage>(new ActivitySummaryKudosMessage(SelectedActivity));
+        }
+
+        private void OnCommentAsync(ActivitySummary activitySummary)
+        {
+            // make sure we work with the swiped item
+            // this could happen if we use the mouse to swipe and move the mouse outside the ListView and release it there
+            if (activitySummary != SelectedActivity)
+            {
+                SelectedActivity = activitySummary;
+            }
+            MessengerInstance.Send<ActivitySummaryCommentMessage>(new ActivitySummaryCommentMessage(SelectedActivity));
         }
     }
 }

--- a/src/Kliva/XAMLResources/DataTemplates.xaml
+++ b/src/Kliva/XAMLResources/DataTemplates.xaml
@@ -5,7 +5,8 @@
     xmlns:controls="using:Kliva.Controls"
     xmlns:interactivity="using:Microsoft.Xaml.Interactivity"
     xmlns:core="using:Microsoft.Xaml.Interactions.Core"
-    xmlns:converters="using:Kliva.Converters">
+    xmlns:converters="using:Kliva.Converters"
+    xmlns:uwpToolkitControls="using:Microsoft.Toolkit.Uwp.UI.Controls">
 
     <converters:DistanceUnitToStringConverter x:Key="DistanceUnitToStringConverter" />
     <converters:SpeedUnitToStringConverter x:Key="SpeedUnitToStringConverter" />
@@ -16,58 +17,73 @@
     <DataTemplate x:Key="ActivityListItemDataTemplate"
                   x:DataType="models:ActivitySummary">
         <!-- UserControl needed for visual state manager -->
-        <UserControl>
-          <RelativePanel x:Name="ActivityListItemPanel"
+        <uwpToolkitControls:SlidableListItem x:Name="SlidableActivityListItem"
+                                             HorizontalAlignment="Stretch"
+                                             MouseSlidingEnabled="True"
+                                             LeftBackground="{StaticResource KlivaMainBrush}"
+                                             LeftIcon="Like"
+                                             LeftLabel="Give Kudos"
+                                             RightBackground="{StaticResource KlivaMainBrush}"
+                                             RightIcon="Comment"
+                                             RightLabel="Comment">
+            <interactivity:Interaction.Behaviors>
+                <core:DataTriggerBehavior Binding="{x:Bind HasKudoed, Mode=OneWay}" ComparisonCondition="Equal" Value="True">
+                    <core:ChangePropertyAction TargetObject="{Binding ElementName=SlidableActivityListItem}" PropertyName="LeftLabel" Value="View Kudos"/>
+                </core:DataTriggerBehavior>
+            </interactivity:Interaction.Behaviors>
+            <UserControl>
+                <RelativePanel x:Name="ActivityListItemPanel"
                                Margin="0">
-                 <VisualStateManager.VisualStateGroups>
-                    <VisualStateGroup x:Name="VisualStateGroup">
-                        <VisualState x:Name="Mobile">
-                            <VisualState.StateTriggers>
-                                <AdaptiveTrigger MinWindowWidth="320" />
-                            </VisualState.StateTriggers>
-                            <VisualState.Setters>
-                                <Setter Target="AthleteProfilePicture.Style" Value="{StaticResource ProfileEllipseMobile}" />
-                                <Setter Target="ActivityImage.Style" Value="{StaticResource ActivityImageBorderMobile}"/>
-                                <Setter Target="ActivityImageIcon.FontSize" Value="12" />
-                                <Setter Target="ActivityAthleteName.FontSize" Value="12" />
-                                <!-- TODO: Glenn - This is not 100% correct! Because small view on a non Windows 10 Mobile device would also need 15 margin Right because of the 'fat' scrollbar, on WP10 scrollbar design in 'small' -->
-                                <Setter Target="ActivityListItemPanel.Padding" Value="10,10,10,10" />
-                                <Setter Target="ActivityStart.Style" Value="{StaticResource StartTextBlockMobile}" />
-                            </VisualState.Setters>
-                        </VisualState>
-                        <VisualState x:Name="Desktop">
-                            <VisualState.StateTriggers>
-                                <AdaptiveTrigger MinWindowWidth="720" />
-                            </VisualState.StateTriggers>
-                            <VisualState.Setters>
-                                <Setter Target="AthleteProfilePicture.Style" Value="{StaticResource ProfileEllipseDesktop}" />
-                                <Setter Target="ActivityImage.Style" Value="{StaticResource ActivityImageBorderDesktop}"/>
-                                <Setter Target="ActivityImageIcon.FontSize" Value="14" />
-                                <Setter Target="ActivityAthleteName.FontSize" Value="14" />
-                                <Setter Target="ActivityListItemPanel.Padding" Value="10,10,15,10" />
-                                <Setter Target="ActivityStart.Style" Value="{StaticResource StartTextBlockDesktop}" />
-                            </VisualState.Setters>
-                        </VisualState>
-                    </VisualStateGroup>
-                </VisualStateManager.VisualStateGroups>
-                <RelativePanel.Background>
-                    <ImageBrush ImageSource="{x:Bind Map.GoogleImage, Mode=OneWay}" Stretch="UniformToFill" Opacity="0.2" />
-                </RelativePanel.Background>
-                     <interactivity:Interaction.Behaviors>
+                    <VisualStateManager.VisualStateGroups>
+                        <VisualStateGroup x:Name="VisualStateGroup">
+                            <VisualState x:Name="Mobile">
+                                <VisualState.StateTriggers>
+                                    <StateTrigger></StateTrigger>
+                                    <AdaptiveTrigger MinWindowWidth="320" />
+                                </VisualState.StateTriggers>
+                                <VisualState.Setters>
+                                    <Setter Target="AthleteProfilePicture.Style" Value="{StaticResource ProfileEllipseMobile}" />
+                                    <Setter Target="ActivityImage.Style" Value="{StaticResource ActivityImageBorderMobile}"/>
+                                    <Setter Target="ActivityImageIcon.FontSize" Value="12" />
+                                    <Setter Target="ActivityAthleteName.FontSize" Value="12" />
+                                    <!-- TODO: Glenn - This is not 100% correct! Because small view on a non Windows 10 Mobile device would also need 15 margin Right because of the 'fat' scrollbar, on WP10 scrollbar design in 'small' -->
+                                    <Setter Target="ActivityListItemPanel.Padding" Value="10,10,10,10" />
+                                    <Setter Target="ActivityStart.Style" Value="{StaticResource StartTextBlockMobile}" />
+                                </VisualState.Setters>
+                            </VisualState>
+                            <VisualState x:Name="Desktop">
+                                <VisualState.StateTriggers>
+                                    <AdaptiveTrigger MinWindowWidth="720" />
+                                </VisualState.StateTriggers>
+                                <VisualState.Setters>
+                                    <Setter Target="AthleteProfilePicture.Style" Value="{StaticResource ProfileEllipseDesktop}" />
+                                    <Setter Target="ActivityImage.Style" Value="{StaticResource ActivityImageBorderDesktop}"/>
+                                    <Setter Target="ActivityImageIcon.FontSize" Value="14" />
+                                    <Setter Target="ActivityAthleteName.FontSize" Value="14" />
+                                    <Setter Target="ActivityListItemPanel.Padding" Value="10,10,15,10" />
+                                    <Setter Target="ActivityStart.Style" Value="{StaticResource StartTextBlockDesktop}" />
+                                </VisualState.Setters>
+                            </VisualState>
+                        </VisualStateGroup>
+                    </VisualStateManager.VisualStateGroups>
+                    <RelativePanel.Background>
+                        <ImageBrush ImageSource="{x:Bind Map.GoogleImage, Mode=OneWay}" Stretch="UniformToFill" Opacity="0.2" />
+                    </RelativePanel.Background>
+                    <interactivity:Interaction.Behaviors>
                         <core:DataTriggerBehavior Binding="{x:Bind OtherAthleteCount, Mode=OneWay}" ComparisonCondition="GreaterThan" Value="0">
-                        <core:ChangePropertyAction TargetObject="{Binding ElementName=AthleteCountPanel}" PropertyName="Visibility" Value="Visible"/>
-                    </core:DataTriggerBehavior>
-                            <core:DataTriggerBehavior Binding="{x:Bind OtherAthleteCount, Mode=OneWay}" ComparisonCondition="LessThanOrEqual" Value="0">
-                        <core:ChangePropertyAction TargetObject="{Binding ElementName=AthleteCountPanel}" PropertyName="Visibility" Value="Collapsed"/>
-                    </core:DataTriggerBehavior>
+                            <core:ChangePropertyAction TargetObject="{Binding ElementName=AthleteCountPanel}" PropertyName="Visibility" Value="Visible"/>
+                        </core:DataTriggerBehavior>
+                        <core:DataTriggerBehavior Binding="{x:Bind OtherAthleteCount, Mode=OneWay}" ComparisonCondition="LessThanOrEqual" Value="0">
+                            <core:ChangePropertyAction TargetObject="{Binding ElementName=AthleteCountPanel}" PropertyName="Visibility" Value="Collapsed"/>
+                        </core:DataTriggerBehavior>
 
-                    <core:DataTriggerBehavior Binding="{x:Bind AchievementCount, Mode=OneWay}" ComparisonCondition="GreaterThan" Value="0">
-                        <core:ChangePropertyAction TargetObject="{Binding ElementName=AchievementPanel}" PropertyName="Visibility" Value="Visible"/>
-                    </core:DataTriggerBehavior>
-                    <core:DataTriggerBehavior Binding="{x:Bind AchievementCount, Mode=OneWay}" ComparisonCondition="LessThanOrEqual" Value="0">
-                        <core:ChangePropertyAction TargetObject="{Binding ElementName=AchievementPanel}" PropertyName="Visibility" Value="Collapsed"/>
-                    </core:DataTriggerBehavior>
-                </interactivity:Interaction.Behaviors>
+                        <core:DataTriggerBehavior Binding="{x:Bind AchievementCount, Mode=OneWay}" ComparisonCondition="GreaterThan" Value="0">
+                            <core:ChangePropertyAction TargetObject="{Binding ElementName=AchievementPanel}" PropertyName="Visibility" Value="Visible"/>
+                        </core:DataTriggerBehavior>
+                        <core:DataTriggerBehavior Binding="{x:Bind AchievementCount, Mode=OneWay}" ComparisonCondition="LessThanOrEqual" Value="0">
+                            <core:ChangePropertyAction TargetObject="{Binding ElementName=AchievementPanel}" PropertyName="Visibility" Value="Collapsed"/>
+                        </core:DataTriggerBehavior>
+                    </interactivity:Interaction.Behaviors>
 
                     <Ellipse x:Name="AthleteProfilePicture"
                                  RelativePanel.AlignTopWithPanel="True" RelativePanel.AlignBottomWithPanel="True">
@@ -86,107 +102,107 @@
                                        Text="{x:Bind TypeImage, Mode=OneWay}"/>
                     </Border>
 
-                <RelativePanel x:Name="ActivityHighlightsPanel"
+                    <RelativePanel x:Name="ActivityHighlightsPanel"
                                        Margin="15,0,0,0"                                       
                                        RelativePanel.RightOf="ActivityImage"
                                        RelativePanel.AlignTopWithPanel="True" RelativePanel.AlignBottomWithPanel="True"
                                        RelativePanel.AlignRightWithPanel="True">
 
-                    <TextBlock x:Name="ActivityName"
+                        <TextBlock x:Name="ActivityName"
                                        Margin="0,0,0,2.5"
                                        Text="{x:Bind Name, Mode=OneWay}"
                                        Style="{StaticResource WordTrimmingTextBlock}"
                                        FontFamily="{StaticResource OpenSansFontSemibold}"
                                        RelativePanel.AlignTopWithPanel="True" RelativePanel.AlignLeftWithPanel="True" />
 
-                    <TextBlock x:Name="ActivityAthleteName"
+                        <TextBlock x:Name="ActivityAthleteName"
                                        Margin="0,0,0,2.5"                                       
                                        Text="{x:Bind Athlete.FullName, Mode=OneWay}"
                                        Style="{StaticResource CharacterTrimmingTextBlock}"
                                        RelativePanel.Below="ActivityName" RelativePanel.AlignLeftWithPanel="True" />
 
-                    <TextBlock x:Name="ActivityStart"
+                        <TextBlock x:Name="ActivityStart"
                                        Margin="0,0,0,2.5"
                                        Text="{x:Bind StartDate, Mode=OneWay, Converter={StaticResource RelativeTimeConverter}}"                                       
                                        HorizontalAlignment="Right"
                                        RelativePanel.AlignRightWithPanel="True" 
                                        RelativePanel.AlignBottomWith="ActivityAthleteName" />
-                    <!--Stats-->
-                    <TextBlock x:Name="ActivityDistance"
+                        <!--Stats-->
+                        <TextBlock x:Name="ActivityDistance"
                                         Style="{StaticResource BaseTextBlock}"
                                         FontSize="12"
                                         Margin="0, 4, 8, 0"
                                         RelativePanel.Below="ActivityAthleteName"
                                         RelativePanel.AlignLeftWithPanel="True" Text="{x:Bind DistanceUserMeasurementUnit.FormattedValueWithUnit, Mode=OneWay}" />
 
-                    <TextBlock x:Name="ActivityElevation"
+                        <TextBlock x:Name="ActivityElevation"
                                                 Style="{StaticResource BaseTextBlock}"
                                                 FontSize="12"
                                                 Margin="8, 4, 8, 0"
                                                 RelativePanel.RightOf="ActivityDistance"
                                                 RelativePanel.AlignBottomWith="ActivityDistance" Text="{x:Bind ElevationGainUserMeasurementUnit.FormattedValueWithUnit, Mode=OneWay}" />
 
-                    <RelativePanel x:Name="AthleteCountPanel"
+                        <RelativePanel x:Name="AthleteCountPanel"
                                    RelativePanel.RightOf="ActivityElevation"
                                    RelativePanel.AlignVerticalCenterWith="ActivityElevation">
-                    <FontIcon x:Name="AthleteCountIcon"
+                            <FontIcon x:Name="AthleteCountIcon"
                               Glyph="&#xE1E2;"
                                    FontSize="14" Margin="8, 4, 4, 0"
                                    RelativePanel.AlignLeftWithPanel="True"
                                    RelativePanel.AlignVerticalCenterWithPanel="True"/>
 
-                    <TextBlock x:Name="AthleteCount"
+                            <TextBlock x:Name="AthleteCount"
                                    FontSize="12" Margin="4, 4, 8, 0"
                                    RelativePanel.RightOf="AthleteCountIcon"
                                    RelativePanel.AlignVerticalCenterWith="AthleteCountIcon"
                                    Style="{StaticResource BaseTextBlock}"
                                    Text="{x:Bind OtherAthleteCount, Mode=OneWay}"/>
-                    </RelativePanel>
+                        </RelativePanel>
 
-                    <RelativePanel x:Name="AchievementPanel"
+                        <RelativePanel x:Name="AchievementPanel"
                                    RelativePanel.RightOf="AthleteCountPanel"
                                    RelativePanel.AlignVerticalCenterWith="AthleteCountPanel">
-                    <FontIcon x:Name="AchievementIcon"
+                            <FontIcon x:Name="AchievementIcon"
                               Glyph="&#xEC1B;"
                                    FontSize="14" Margin="8, 4, 4, 0"
                                    RelativePanel.AlignLeftWithPanel="True"
                                    RelativePanel.AlignVerticalCenterWithPanel="True"/>
 
-                    <TextBlock x:Name="AchievementCount"
+                            <TextBlock x:Name="AchievementCount"
                                    FontSize="12" Margin="4, 4, 8, 0"
                                    RelativePanel.RightOf="AchievementIcon"
                                    RelativePanel.AlignVerticalCenterWith="AchievementIcon"
                                    Style="{StaticResource BaseTextBlock}" 
                                    Text="{x:Bind AchievementCount, Mode=OneWay}"/>
-                    </RelativePanel>
+                        </RelativePanel>
 
-                    <FontIcon x:Name="CommentsIcon" HorizontalAlignment="Center" Margin="0,4,0,0" 
+                        <FontIcon x:Name="CommentsIcon" HorizontalAlignment="Center" Margin="0,4,0,0" 
                                   Glyph="&#xE15F;" FontSize="14"
                                    RelativePanel.LeftOf="CommentsCount" 
                                    RelativePanel.AlignVerticalCenterWith="CommentsCount"/>
 
-                    <TextBlock x:Name="CommentsCount"
+                        <TextBlock x:Name="CommentsCount"
                                    FontSize="12" Margin="4, 4, 8, 0"
                                    RelativePanel.LeftOf="KudosIcon" 
                                    RelativePanel.AlignVerticalCenterWith="KudosIcon"
                                    Style="{StaticResource BaseTextBlock}" 
                                    Text="{x:Bind CommentCount, Mode=OneWay}" />
 
-
-                    <FontIcon x:Name="KudosIcon" HorizontalAlignment="Center" Margin="4,4,0,0" 
+                        <FontIcon x:Name="KudosIcon" HorizontalAlignment="Center" Margin="4,4,0,0" 
                                   Glyph="&#xE8E1;" FontSize="14"
                                   RelativePanel.LeftOf="KudosCount" 
                                   RelativePanel.AlignVerticalCenterWith="KudosCount"/>
 
-                    <TextBlock x:Name="KudosCount"
+                        <TextBlock x:Name="KudosCount"
                                    FontSize="12" Margin="4, 4, 0, 0"
                                    RelativePanel.Below="ActivityDistance" 
                                    RelativePanel.AlignRightWithPanel="True"
                                    Style="{StaticResource BaseTextBlock}" 
                                    Text="{x:Bind KudosCount, Mode=OneWay}" />
+                    </RelativePanel>
                 </RelativePanel>
-            </RelativePanel>
-        </UserControl>
+            </UserControl>
+        </uwpToolkitControls:SlidableListItem>
     </DataTemplate>
 
     <DataTemplate x:Key="StatisticsGroupHeaderTemplate"
@@ -605,3 +621,4 @@
     </DataTemplate>
 
 </ResourceDictionary>
+

--- a/src/Kliva/XAMLResources/DataTemplates.xaml
+++ b/src/Kliva/XAMLResources/DataTemplates.xaml
@@ -21,9 +21,13 @@
                                              HorizontalAlignment="Stretch"
                                              MouseSlidingEnabled="True"
                                              LeftBackground="{StaticResource KlivaMainBrush}"
+                                             LeftCommand="{Binding Path=Main.KudosCommand, Source={StaticResource Locator}}"
+                                             LeftCommandParameter="{x:Bind}"
                                              LeftIcon="Like"
                                              LeftLabel="Give Kudos"
                                              RightBackground="{StaticResource KlivaMainBrush}"
+                                             RightCommand="{Binding Path=Main.CommentCommand, Source={StaticResource Locator}}"
+                                             RightCommandParameter="{x:Bind}"
                                              RightIcon="Comment"
                                              RightLabel="Comment">
             <interactivity:Interaction.Behaviors>

--- a/src/Kliva/project.json
+++ b/src/Kliva/project.json
@@ -3,6 +3,7 @@
     "Cimbalino.Toolkit": "2.3.0",
     "GoogleAnalyticsSDK": "1.3.0",
     "Microsoft.NETCore.UniversalWindowsPlatform": "5.2.2",
+    "Microsoft.Toolkit.Uwp.UI.Controls": "1.1.0",
     "Microsoft.Xaml.Behaviors.Uwp.Managed": "1.1.0",
     "MvvmLight": "5.3.0",
     "Newtonsoft.Json": "9.0.1",


### PR DESCRIPTION
This PR adds two actions to the activity list.

- Add the UWP Community Toolkit, so we can use the SlidableListItem for this stuff
- Left command selects activity and make the Kudos and/or open the kudos list
- Right command selects activity and opens the comment input dialog (and after this the comment list)
- Also fix not showing comment pivot after swipe it
- Block giving Kudos on own activities

Closes #23 ListView of activities - use swipe to 'like'